### PR TITLE
Pacific Life - Cards - Updated definition and model

### DIFF
--- a/component-definition.json
+++ b/component-definition.json
@@ -115,7 +115,8 @@
                 "resourceType": "core/franklin/components/block/v1/block",
                 "template": {
                   "name": "Cards",
-                  "filter": "cards"
+                  "filter": "cards",
+                  "model": "cards"
                 }
               }
             }

--- a/component-models.json
+++ b/component-models.json
@@ -130,6 +130,28 @@
     ]
   },
   {
+    "id": "cards",
+    "fields": [
+      {
+        "component": "multiselect",
+        "valueType": "string",
+        "name": "classes",
+        "label": "Classes",
+        "value": "",
+        "options": [
+          {
+            "name": "Hero Cards",
+            "value": "hero-cards"
+          },
+          {
+            "name": "Mosaic Cards",
+            "value": "mosaic-cards"
+          }
+        ]
+      }
+    ]
+  },
+  {
     "id": "card",
     "fields": [
       {


### PR DESCRIPTION
Updated cards definition and model to allow multiselect of cards classes.

Test URLs:
- Before: https://main--pacificlife--smruti1987.hlx.live/
- After: https://<branch>--pacificlife--smruti1987.hlx.live/
